### PR TITLE
exclude javax.servlet from Flink dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -708,6 +708,12 @@
 			<artifactId>flink-java</artifactId>
 			<version>${flink.version}</version>
 			<scope>provided</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.servlet</groupId>
+                    <artifactId>servlet-api</artifactId>
+                </exclusion>
+            </exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.flink</groupId>


### PR DESCRIPTION
With this change all original tests run through
